### PR TITLE
Capture output using snapshots

### DIFF
--- a/tests/testthat/_snaps/dplyr.md
+++ b/tests/testthat/_snaps/dplyr.md
@@ -1,0 +1,28 @@
+# dplyr left_join
+
+    Code
+      joined <- left_join(myresult, joindf)
+    Message <rlang_message>
+      Joining, by = "ID"
+
+---
+
+    Code
+      joined_manual$result <- dplyr::left_join(joined_manual$result, joindf)
+    Message <rlang_message>
+      Joining, by = "ID"
+
+---
+
+    Code
+      joined <- left_join(myconc, joindf)
+    Message <rlang_message>
+      Joining, by = "ID"
+
+---
+
+    Code
+      joined_manual$data <- left_join(joined_manual$data, joindf)
+    Message <rlang_message>
+      Joining, by = "ID"
+

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -7,12 +7,12 @@ test_that("dplyr filter", {
   mydose <- PKNCAdose(tmpdose, formula=dose~time|treatment+ID)
   mydata <- PKNCAdata(myconc, mydose)
   myresult <- pk.nca(mydata)
-  
+
   filtered <- filter(myresult, PPTESTCD == "auclast")
   filtered_manual <- myresult
   filtered_manual$result <- filtered_manual$result[filtered_manual$result$PPTESTCD == "auclast", ]
   expect_equal(filtered, filtered_manual)
-  
+
   filtered <- filter(myconc, ID == 1)
   filtered_manual <- myconc
   filtered_manual$data <- myconc$data[myconc$data$ID == 1, ]
@@ -26,27 +26,23 @@ test_that("dplyr left_join", {
   mydose <- PKNCAdose(tmpdose, formula=dose~time|treatment+ID)
   mydata <- PKNCAdata(myconc, mydose)
   myresult <- pk.nca(mydata)
-  
+
   joindf <- data.frame(ID=1, foo="bar")
-  expect_message(
-    joined <- left_join(myresult, joindf),
-    "Joining, by = \"ID\""
+  expect_snapshot(
+    joined <- left_join(myresult, joindf)
   )
   joined_manual <- myresult
-  expect_message(
-    joined_manual$result <- dplyr::left_join(joined_manual$result, joindf),
-    "Joining, by = \"ID\""
+  expect_snapshot(
+    joined_manual$result <- dplyr::left_join(joined_manual$result, joindf)
   )
   expect_equal(joined, joined_manual)
-  
-  expect_message(
-    joined <- left_join(myconc, joindf),
-    "Joining, by = \"ID\""
+
+  expect_snapshot(
+    joined <- left_join(myconc, joindf)
   )
   joined_manual <- myconc
-  expect_message(
-    joined_manual$data <- left_join(joined_manual$data, joindf),
-    "Joining, by = \"ID\""
+  expect_snapshot(
+    joined_manual$data <- left_join(joined_manual$data, joindf)
   )
   expect_equal(joined, joined_manual)
 })
@@ -58,12 +54,12 @@ test_that("dplyr mutate", {
   mydose <- PKNCAdose(tmpdose, formula=dose~time|treatment+ID)
   mydata <- PKNCAdata(myconc, mydose)
   myresult <- pk.nca(mydata)
-  
+
   mutated <- mutate(myresult, foo="bar")
   mutated_manual <- myresult
   mutated_manual$result <- mutate(mutated_manual$result, foo="bar")
   expect_equal(mutated, mutated_manual)
-  
+
   mutated <- mutate(myconc, foo="bar")
   mutated_manual <- myconc
   mutated_manual$data <- mutate(mutated_manual$data, foo="bar")
@@ -77,7 +73,7 @@ test_that("dplyr group_by and ungroup", {
   mydose <- PKNCAdose(tmpdose, formula=dose~time|treatment+ID)
   mydata <- PKNCAdata(myconc, mydose)
   myresult <- pk.nca(mydata)
-  
+
   grouped <- group_by(myconc, treatment)
   expect_s3_class(grouped$data, "grouped_df")
   ungrouped <- ungroup(grouped)


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

You were explicitly testing the message that `left_join()` returns when it tells you the common variables it joins by. We highly discourage this, because you don't own that message, and in fact we have changed it in the next version of dplyr. If you must do this, use a snapshot test so that it won't break on CRAN if we do change it. That is what I've done here (captured with CRAN dplyr), but I'd encourage you to just remove these tests altogether if you really don't care about them.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!