### PR TITLE
aucint.inf.obs now returns zero with all zero concentrations via `pk.nca()` (fix #253)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,7 @@ the dosing including dose amount and route.
 * Concentration extrapolation with `extrapolate.conc()` using the "AUCall"
   method now has decreasing instead of increasing concentrations (#249).
 * The aucint.inf.obs parameter when calculated with all zero concentrations
-  returns zero (#253).
+  returns zero and aucint.inf.pred returns `NA_real_` (#253)
 
 ## Breaking changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@ the dosing including dose amount and route.
   default.
 * Concentration extrapolation with `extrapolate.conc()` using the "AUCall"
   method now has decreasing instead of increasing concentrations (#249).
+* The aucint.inf.obs parameter when calculated with all zero concentrations
+  returns zero (#253).
 
 ## Breaking changes
 
@@ -46,6 +48,8 @@ the dosing including dose amount and route.
 * `check.conc.time()` is defunct (it was never intended to be an external
   function).  It has been replaced by `assert_conc()`, `assert_time()` and
   `assert_conc_time()`.
+* The clast.obs parameter is now zero when all concentrations are zero (see #253
+  for part of the reason).
 
 ## Changes under the hood
 

--- a/R/aucint.R
+++ b/R/aucint.R
@@ -69,8 +69,11 @@ pk.calc.aucint <- function(conc, time,
   time_clast <- NULL
   if (auc.type %in% "AUCinf") {
     tlast <- pk.calc.tlast(conc=data$conc, time=data$time)
-    if (clast != pk.calc.clast.obs(conc=data$conc, time=data$time) &
-        interval[2] > tlast) {
+    clast_obs <- pk.calc.clast.obs(conc=data$conc, time=data$time)
+    if (is.na(clast)) {
+      # All concentrations are NA
+      return(structure(NA_real_, exclude = "clast is NA"))
+    } else if (clast != clast_obs & interval[2] > tlast) {
       # If using clast.pred, we need to doubly calculate at tlast.
       conc_clast <- clast
       time_clast <- tlast

--- a/R/pk.calc.all.R
+++ b/R/pk.calc.all.R
@@ -230,7 +230,7 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
       dose_data_interval <- NA_data_dose_
     }
     # Setup for detailed error reporting in case it's needed
-    error.preamble <-
+    error_preamble <-
       paste(
         "Error with interval",
         paste(
@@ -239,7 +239,7 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
           sep="=", collapse=", ")
       )
     if (nrow(conc_data_interval) == 0) {
-      warning(paste(error.preamble, "No data for interval", sep=": "))
+      warning(paste(error_preamble, "No data for interval", sep=": "))
     } else if (!has_calc_sparse_dense) {
       if (verbose) message("No ", ifelse(sparse, "sparse", "dense"), " calculations requested for an interval")
     } else {
@@ -283,7 +283,7 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
         args$exclude_half.life <- conc_data_interval$exclude_half.life
       }
       # Try the calculation
-      calculated.interval <-
+      calculated_interval <-
         tryCatch(
           do.call(pk.nca.interval, args),
           error=function(e) {
@@ -297,7 +297,7 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
           ret,
           cbind(
             current_interval[, c("start", "end")],
-            calculated.interval,
+            calculated_interval,
             row.names=NULL
           )
         )
@@ -399,8 +399,6 @@ pk.nca.interval <- function(conc, time, volume, duration.conc,
       interval[all_intervals[[n]]$depends] <- TRUE
     }
   }
-  # Check if units will be used
-  #uses_units <- inherits(time, "units")
   # Do the calculations
   for (n in names(all_intervals)) {
     request_to_calculate <- as.logical(interval[[n]])

--- a/R/pk.calc.simple.R
+++ b/R/pk.calc.simple.R
@@ -200,8 +200,10 @@ PKNCA.set.summary(
 #' Determine the last observed concentration above the limit of
 #' quantification (LOQ).
 #'
-#' If Tlast is NA (due to no non-missing above LOQ measurements), this
-#' will return NA.
+#' If all concentrations are missing, `NA_real_` is returned.  If all
+#' concentrations are zero (below the limit of quantification) or missing, zero
+#' is returned.  If Tlast is NA (due to no non-missing above LOQ measurements),
+#' this will return `NA_real_`.
 #'
 #' @inheritParams assert_conc_time
 #' @param check Run \code{\link{assert_conc_time}}?
@@ -212,11 +214,17 @@ pk.calc.clast.obs <- function(conc, time, check=TRUE) {
   if (check) {
     assert_conc_time(conc = conc, time = time)
   }
-  tlast <- pk.calc.tlast(conc, time, check = FALSE)
-  if (!is.na(tlast)) {
-    conc[time %in% tlast]
+  if (all(is.na(conc))) {
+    NA_real_
+  } else if (all(conc %in% c(0, NA))) {
+    0
   } else {
-    NA
+    tlast <- pk.calc.tlast(conc, time, check = FALSE)
+    if (!is.na(tlast)) {
+      conc[time %in% tlast]
+    } else {
+      NA_real_
+    }
   }
 }
 # Add the column to the interval specification

--- a/man/pk.calc.clast.obs.Rd
+++ b/man/pk.calc.clast.obs.Rd
@@ -18,8 +18,10 @@ pk.calc.clast.obs(conc, time, check = TRUE)
 The last observed concentration above the LOQ
 }
 \description{
-If Tlast is NA (due to no non-missing above LOQ measurements), this
-will return NA.
+If all concentrations are missing, `NA_real_` is returned.  If all
+concentrations are zero (below the limit of quantification) or missing, zero
+is returned.  If Tlast is NA (due to no non-missing above LOQ measurements),
+this will return `NA_real_`.
 }
 \seealso{
 Other NCA parameters for concentrations during the intervals: 

--- a/tests/testthat/test-aucint.R
+++ b/tests/testthat/test-aucint.R
@@ -367,3 +367,14 @@ test_that("aucint respects the check argument", {
     pk.calc.aucint.last(conc = baddata$conc, time = baddata$time, start = 0, end = Inf, check = FALSE)
   )
 })
+
+test_that("aucint works for all zero concentrations with interpolated or extrapolated concentrations", {
+  expect_equal(
+    pk.calc.aucint(conc = c(0, 0, 0, 0), time = 0:3, interval = c(0, 4)),
+    structure(0, exclude = "DO NOT EXCLUDE")
+  )
+  expect_equal(
+    pk.calc.aucint(conc = c(0, 0, 0, 0), time = 0:3, interval = c(0, 2.5)),
+    structure(0, exclude = "DO NOT EXCLUDE")
+  )
+})

--- a/tests/testthat/test-pk.calc.all.R
+++ b/tests/testthat/test-pk.calc.all.R
@@ -608,3 +608,24 @@ test_that("Unexpected interval columns do not cause an error (#238)", {
   o_data <- PKNCAdata(o_conc, o_dose, intervals = d_intervals)
   expect_s3_class(pk.nca(o_data), "PKNCAresults")
 })
+
+test_that("aucint works within pk.calc.all for all zero concentrations with interpolated or extrapolated concentrations", {
+  d_interval <- data.frame(start = 0, end = 4, aucint.inf.obs = TRUE)
+  d_conctime <- data.frame(conc = c(0, 0, 0, 0), time = 0:3)
+  o_conc <- PKNCAconc(d_conctime, conc~time)
+  o_data <- PKNCAdata(o_conc, intervals = d_interval)
+  suppressWarnings(suppressMessages(
+    o_nca <- pk.nca(o_data)
+  ))
+  results <- setNames(as.data.frame(o_nca)$PPORRES, nm = as.data.frame(o_nca)$PPTESTCD)
+  zero_names <- c("clast.obs", "aucint.inf.obs")
+  na_names <- setdiff(names(results), zero_names)
+  expect_equal(
+    results[zero_names],
+    setNames(rep(0, length(zero_names)), zero_names)
+  )
+  expect_equal(
+    results[na_names],
+    setNames(rep(NA_real_, length(na_names)), na_names)
+  )
+})

--- a/tests/testthat/test-pk.calc.all.R
+++ b/tests/testthat/test-pk.calc.all.R
@@ -610,6 +610,7 @@ test_that("Unexpected interval columns do not cause an error (#238)", {
 })
 
 test_that("aucint works within pk.calc.all for all zero concentrations with interpolated or extrapolated concentrations", {
+  # AUCint.inf.obs
   d_interval <- data.frame(start = 0, end = 4, aucint.inf.obs = TRUE)
   d_conctime <- data.frame(conc = c(0, 0, 0, 0), time = 0:3)
   o_conc <- PKNCAconc(d_conctime, conc~time)
@@ -627,5 +628,18 @@ test_that("aucint works within pk.calc.all for all zero concentrations with inte
   expect_equal(
     results[na_names],
     setNames(rep(NA_real_, length(na_names)), na_names)
+  )
+
+  # AUCint.inf.pred
+  d_interval <- data.frame(start = 0, end = 4, aucint.inf.pred = TRUE)
+  d_conctime <- data.frame(conc = c(0, 0, 0, 0), time = 0:3)
+  o_conc <- PKNCAconc(d_conctime, conc~time)
+  o_data <- PKNCAdata(o_conc, intervals = d_interval)
+  suppressWarnings(suppressMessages(
+    o_nca <- pk.nca(o_data)
+  ))
+  expect_equal(
+    as.data.frame(o_nca)$PPORRES,
+    rep(NA_real_, 11)
   )
 })

--- a/tests/testthat/test-pk.calc.simple.R
+++ b/tests/testthat/test-pk.calc.simple.R
@@ -152,11 +152,11 @@ test_that("pk.calc.clast.obs", {
     v1 <- pk.calc.clast.obs(c1, t1),
     class = "pknca_conc_all_missing"
   )
-  expect_equal(v1, NA)
+  expect_equal(v1, NA_real_)
 
   c1 <- rep(0, 4)
   t1 <- c(0, 1, 2, 3)
-  expect_equal(pk.calc.clast.obs(c1, t1), NA)
+  expect_equal(pk.calc.clast.obs(c1, t1), 0)
 })
 
 test_that("pk.calc.thalf.eff", {


### PR DESCRIPTION
aucint.inf.obs now returns zero with all zero concentrations via `pk.nca()` (fix #253)