### PR TITLE
[WIP] return individual fit info, first version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ inst/doc
 Rprof.out
 .Rhistory
 /revdep
+.Rproj.user


### PR DESCRIPTION
This PR implements changes to return the individual fit info (predictions, and coefficients) from the half-life/lambda-z fits done during NCA. This is useful info to have, as it can (should) be used to inspect the individual fits.