### PR TITLE
intervals columns attributes are preserved and do not cause an error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,8 @@ the dosing including dose amount and route.
   applied (the interval is treated as-is, like the argument had not been given).
   If some values are `NA` for the interval, those are treated as `FALSE`.
 * `group_vars()` methods were added for `PKNCAdata` and `PKNCAresults` objects.
+* If intervals have attributes on the columns, there will no longer be an error
+  during parameter calculation, and the attributes are preserved (#381)
 
 # Minor changes (unlikely to affect PKNCA use)
 

--- a/R/pk.calc.all.R
+++ b/R/pk.calc.all.R
@@ -281,15 +281,18 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
           }
         )
       # Add all the new data into the output
-      ret <-
-        rbind(
-          ret,
-          cbind(
-            current_interval[, c("start", "end", options$keep_interval_cols)],
-            calculated_interval,
-            row.names=NULL
-          )
+      new_ret <-
+        cbind(
+          # The rep(1, ...) is to fix #381 where attributes on an interval
+          # column cause cbind to fail
+          current_interval[
+            rep(1, nrow(calculated_interval)),
+            c("start", "end", options$keep_interval_cols)
+          ],
+          calculated_interval,
+          row.names=NULL
         )
+      ret <- rbind(ret, new_ret)
     }
   }
   ret

--- a/tests/testthat/test-pk.calc.all.R
+++ b/tests/testthat/test-pk.calc.all.R
@@ -743,3 +743,18 @@ test_that("dose is calculable", {
   expect_equal(as.data.frame(myresult)$PPORRES, rep(2, 2))
   expect_equal(as.data.frame(myresult)$PPTESTCD, rep("totdose", 2))
 })
+
+test_that("do not give rbind error when interval columns have attributes (#381)", {
+  o_conc <- PKNCAconc(data = data.frame(conc = 1, time = 0), conc~time)
+  d_interval <- data.frame(start = 0, end = Inf, cmax = TRUE)
+
+  d_interval <- data.frame(start = 0, end = Inf, cmax = TRUE, tmax = TRUE)
+  attr(d_interval$start, "label") <- "start"
+  o_data <- PKNCAdata(o_conc, intervals = d_interval)
+  suppressMessages(o_nca <- pk.nca(o_data))
+  # interval attributes are preserved
+  expect_equal(
+    attributes(as.data.frame(o_nca)$start),
+    list(label = "start")
+  )
+})


### PR DESCRIPTION
Fix #381