### PR TITLE
fix: use stats::sd instead of bare sd in pk.calc.half.life

### DIFF
--- a/R/half.life.R
+++ b/R/half.life.R
@@ -176,7 +176,7 @@ pk.calc.half.life <- function(conc, time, tmax, tlast,
     dfK <- data[as.numeric(data$time) > as.numeric(ret$tmax), ]
   }
   # When all concentrations are the same (non-zero) value cannot compute half-life (#503)
-  if (isTRUE(sd(data$log_conc[is.finite(data$log_conc)], na.rm = TRUE) == 0)) {
+  if (isTRUE(stats::sd(data$log_conc[is.finite(data$log_conc)], na.rm = TRUE) == 0)) {
     attr(ret, "exclude") <- "No point variability in concentrations for half-life calculation"
     return(ret)
   }


### PR DESCRIPTION
Qualify the call to sd() with its namespace to avoid relying on implicit availability of stats functions.