### PR TITLE
Replace while-loop dependency sort with Kahn's topological sort algorithm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,16 @@ the dosing including dose amount and route.
 
 # Development version
 
+## New features
+* Dependency resolution for interval columns now uses Kahn's topological
+  sorting algorithm (`topological_sort()`), replacing the previous
+  while-loop implementation. Key improvements:
+  - Circular dependencies (e.g., parameter A depends on B, B depends on A)
+    are now detected and reported with a clear error. Previously, circular
+    dependencies would cause an infinite loop with no error message.
+  - Missing dependencies now return a clearer error message with error
+    class `pknca_error_missing_dependency` for programmatic handling.
+
 ## Breaking changes
 
 * Both include and excluding half-life points may not be done for the same interval (#406)

--- a/R/001-add.interval.col.R
+++ b/R/001-add.interval.col.R
@@ -3,6 +3,7 @@
 assign("options", NULL, envir=.PKNCAEnv)
 assign("summary", list(), envir=.PKNCAEnv)
 assign("interval.cols", list(), envir=.PKNCAEnv)
+assign("interval.cols_sorted", NULL, envir = .PKNCAEnv)
 
 #' Add columns for calculations within PKNCA intervals
 #'
@@ -175,6 +176,171 @@ add.interval.col <- function(name,
   assign("interval.cols", current, envir=.PKNCAEnv)
 }
 
+#' Perform topological sort of interval column specifications (Kahn's algorithm)
+#'
+#' Orders interval columns so that each parameter appears after
+#' all parameters it depends on. Used internally by [sort.interval.cols()]
+#' to ensure parameters are calculated in the correct dependency order.
+#'
+#' @param specs Named list of interval column specifications, where each
+#'   element is a list containing at minimum a `depends` field (character
+#'   vector of parameter names, or `NULL` for no dependencies).
+#'
+#' @return Character vector of sorted parameter names in topologically
+#'   sorted order (dependencies appear before dependent parameters).
+#'
+#' @details
+#' The function performs the following validations:
+#' \itemize{
+#'   \item Validates that `specs` is a properly structured named list
+#'   \item Ensures all dependencies reference existing parameters
+#'   \item Detects circular dependencies (returns error if found)
+#'   \item Returns deterministic ordering based on insertion order
+#'     when multiple valid orderings exist
+#' }
+#'
+#' The algorithm uses Kahn's topological sorting algorithm with
+#' insertion-order tie-breaking to ensure consistent results that
+#' preserve the original parameter registration order.
+#'
+#' @section Errors:
+#' The function will abort with an error if:
+#' \itemize{
+#'   \item Any parameter's `depends` field references a non-existent parameter
+#'     (class: `pknca_error_missing_dependency`)
+#'   \item A circular dependency is detected
+#'     (class: `pknca_error_circular_dependency`)
+#'   \item The structure of `specs` is invalid
+#'     (class: `pknca_error_invalid_spec_structure`)
+#' }
+#'
+#' @keywords internal
+#' @noRd
+topological_sort <- function(specs) {
+  
+  # ------------------------------------------------------------
+  # 1. Structural validation
+  # Ensure specs is a non-empty named list with unique names
+  # and each element contains a valid 'depends' field
+  # ------------------------------------------------------------
+  checkmate::assert_list(
+    specs,
+    names = "named",
+    min.len = 1,
+    .var.name = "specs"
+  )
+  
+  checkmate::assert_names(
+    names(specs),
+    type = "unique",
+    .var.name = "names(specs)"
+  )
+  
+  for (nm in names(specs)) {
+    checkmate::assert_list(
+      specs[[nm]],
+      .var.name = paste0("specs[['", nm, "']]")
+    )
+    
+    # Every spec element must have a 'depends' field (can be NULL)
+    if (!"depends" %in% names(specs[[nm]])) {
+      rlang::abort(
+        sprintf("Column '%s' must contain a 'depends' field", nm),
+        class = "pknca_error_invalid_spec_structure"
+      )
+    }
+    
+    # 'depends' must be a character vector if not NULL
+    if (!is.null(specs[[nm]]$depends)) {
+      checkmate::assert_character(
+        specs[[nm]]$depends,
+        any.missing = FALSE,
+        .var.name = paste0("specs[['", nm, "']]$depends")
+      )
+    }
+  }
+  
+  params <- names(specs)
+  n <- length(params)
+  
+  # ------------------------------------------------------------
+  # 2. Validate all dependencies reference existing parameters
+  # Collect all missing deps across all specs in one pass
+  # ------------------------------------------------------------
+  missing <- unique(unlist(lapply(specs, function(spec) {
+    if (is.null(spec$depends)) return(character(0))
+    setdiff(spec$depends, params)
+  }), use.names = FALSE))
+  
+  if (length(missing)) {
+    rlang::abort(
+      sprintf(
+        "Missing interval column definitions for: %s",
+        paste(dQuote(missing), collapse = ", ")
+      ),
+      class = "pknca_error_missing_dependency"
+    )
+  }
+  
+  # ------------------------------------------------------------
+  # 3. Build dependency graph
+  # in_deg: number of unresolved dependencies per parameter
+  # adj: adjacency list — adj[[p]] lists params that depend on p
+  # ------------------------------------------------------------
+  in_deg <- setNames(integer(n), params)
+  adj    <- setNames(vector("list", n), params)
+  
+  for (p in params) {
+    deps <- specs[[p]]$depends
+    if (is.null(deps)) next  # no dependencies, skip
+    for (d in deps) {
+      adj[[d]] <- c(adj[[d]], p)  # p depends on d, so d -> p edge
+      in_deg[p] <- in_deg[p] + 1
+    }
+  }
+  
+  # ------------------------------------------------------------
+  # 4. Kahn's algorithm — insertion order tie-breaking
+  # Start with all params that have no dependencies (in_deg == 0)
+  # Process one at a time, reducing in_deg of dependents
+  # Insertion order is preserved (no sorting) for consistent output
+  # ------------------------------------------------------------
+  queue  <- params[in_deg == 0]  # initial queue in insertion order
+  result <- character(n)
+  idx    <- 1
+  
+  while (length(queue)) {
+    node  <- queue[1]
+    queue <- queue[-1]
+    
+    result[idx] <- node
+    idx <- idx + 1
+    
+    # Reduce in_deg for all params that depend on this node
+    # When in_deg reaches 0, the param is ready to be processed
+    for (nbr in adj[[node]]) {
+      in_deg[nbr] <- in_deg[nbr] - 1
+      if (in_deg[nbr] == 0) {
+        queue <- c(queue, nbr)  # append in insertion order
+      }
+    }
+  }
+  
+  # ------------------------------------------------------------
+  # 5. Cycle detection
+  # If not all params were processed, a cycle exists
+  # (nodes in a cycle never reach in_deg == 0)
+  # ------------------------------------------------------------
+  if (idx <= n) {
+    rlang::abort(
+      "Circular dependency detected in interval column specifications",
+      class = "pknca_error_circular_dependency"
+    )
+  }
+  
+  result
+}
+
 #' Sort the interval columns by dependencies.
 #'
 #' Columns are always to the right of columns that they depend on.
@@ -182,43 +348,22 @@ sort.interval.cols <- function() {
   current <- get("interval.cols", envir=.PKNCAEnv)
   # Only sort if necessary
   sort_order <- get0("interval.cols_sorted", envir=.PKNCAEnv)
+  
   if (identical(sort_order, names(current))) {
     # It is already sorted
     return(sort_order)
   }
-  # Build a dependency tree
-  myorder <- rep(NA, length(current))
-  names(myorder) <- names(current)
-  nextnum <- 1
-  while (any(is.na(myorder))) {
-    for (nextorder in seq_along(myorder)[is.na(myorder)]) {
-      if (length(current[[nextorder]]$depends) == 0) {
-        # If it doesn't depend on anything then it can go next in order.
-        myorder[nextorder] <- nextnum
-        nextnum <- nextnum + 1
-      } else {
-        # If all of its dependencies already have values, then it can be next.
-        deps <- unique(unlist(current[[nextorder]]$depends))
-        missing_deps <- deps[!(deps %in% names(myorder))]
-        if (length(missing_deps) > 0) {
-          stop(
-            "Invalid dependencies for interval column (please report this as a bug): ",
-            names(myorder)[nextorder],
-            " The following dependencies are missing: ",
-            paste(missing_deps, collapse=", ")
-          )
-        }
-        if (!any(is.na(myorder[deps]))) {
-          myorder[nextorder] <- nextnum
-          nextnum <- nextnum + 1
-        }
-      }
-    }
-  }
-  current <- current[names(sort(myorder))]
-  assign("interval.cols_sorted", names(current), envir=.PKNCAEnv)
-  assign("interval.cols", current, envir=.PKNCAEnv)
-  invisible(myorder)
+  
+  # ------------------------------------------------------------
+  # Topological sort
+  # ------------------------------------------------------------
+  order <- topological_sort(current) # N
+  
+  # Update environment
+  assign("interval.cols", current[order], envir = .PKNCAEnv)
+  assign("interval.cols_sorted", order, envir = .PKNCAEnv)
+  
+  invisible(order)
 }
 
 #' Get the columns that can be used in an interval specification

--- a/tests/testthat/test-001-add.interval.col.R
+++ b/tests/testthat/test-001-add.interval.col.R
@@ -13,7 +13,6 @@ test_that("add.interval.col", {
     regexp="name must have length",
     info="interval column name must be a scalar character string"
   )
-
   expect_error(
     add.interval.col(name="a", FUN=c("a", "b")),
     regexp="FUN must have length == 1",
@@ -24,7 +23,6 @@ test_that("add.interval.col", {
     regexp="FUN must be a character string or NA",
     info="interval column function must be a character string or NA"
   )
-  
   expect_error(
     add.interval.col(name="a", FUN=NA, datatype="interval", desc="test addition"),
     regexp='argument "unit_type" is missing, with no default'
@@ -47,13 +45,11 @@ test_that("add.interval.col", {
     add.interval.col(name="a", FUN=NA, unit_type="conc", pretty_name="", datatype="interval", desc=1),
     regexp="pretty_name must not be an empty string"
   )
-  
   expect_error(
     add.interval.col(name="a", FUN=NA, unit_type="conc", pretty_name="a", datatype="individual"),
     regexp="Only the 'interval' datatype is currently supported.",
     info="interval column datatype must be 'interval'"
   )
-  
   expect_error(
     add.interval.col(name="a", FUN=NA, unit_type="conc", pretty_name="a", datatype="interval", desc=1:2),
     regexp="desc must have length == 1",
@@ -65,17 +61,16 @@ test_that("add.interval.col", {
     info="interval column description must be a character scalar"
   )
   expect_error(
-    add.interval.col(name="a", FUN=NA, depends = 1, unit_type="conc", pretty_name="a", datatype="interval", desc=1),
+    add.interval.col(name="a", FUN=NA, depends=1, unit_type="conc", pretty_name="a", datatype="interval", desc=1),
     regexp="'depends' must be NULL or a character vector",
-    info="depends column must be a NULL or a character string"
+    info="depends column must be NULL or a character string"
   )
-  
   expect_error(
     add.interval.col(name="a", FUN="this function does not exist", unit_type="conc", pretty_name="foo", datatype="interval", desc="test addition"),
     regexp="The function named '.*' is not defined.  Please define the function before calling add.interval.col.",
     info="interval column function must exist (or be NA)"
   )
-
+  
   # formalsmap
   expect_error(
     add.interval.col(name="a", FUN="mean", unit_type="conc", pretty_name="foo", formalsmap=NA),
@@ -100,6 +95,7 @@ test_that("add.interval.col", {
     info="formalsmap arguments must map to function arguments"
   )
   
+  # Correct storage - FUN=NA
   expect_equal(
     {
       add.interval.col(name="a", FUN=NA, unit_type="conc", pretty_name="a", datatype="interval", desc="test addition")
@@ -118,6 +114,8 @@ test_that("add.interval.col", {
     ),
     info="interval column assignment works with FUN=NA"
   )
+  
+  # Correct storage - FUN=character
   expect_equal(
     {
       add.interval.col(name="a", FUN="mean", unit_type="conc", pretty_name="a", datatype="interval", desc="test addition")
@@ -136,6 +134,8 @@ test_that("add.interval.col", {
     ),
     info="interval column assignment works with FUN=a character string"
   )
+  
+  # Correct storage - with formalsmap
   expect_equal(
     {
       add.interval.col(name="a", FUN="mean", unit_type="conc", pretty_name="a", formalsmap=list(x="values"), desc="test addition")
@@ -152,14 +152,19 @@ test_that("add.interval.col", {
       depends=NULL,
       datatype="interval"
     ),
-    info="interval column assignment works with FUN=NA"
+    info="interval column assignment works with formalsmap"
   )
 })
 
 # Reset the original state
 assign("interval.cols", original_state, envir=PKNCA:::.PKNCAEnv)
+assign("interval.cols_sorted", NULL, envir=PKNCA:::.PKNCAEnv)
 
-test_that("fake parameters", {
+# ---------------------------------------------------------------------------
+# sort.interval.cols — missing dependency (topological_sort integration)
+# ---------------------------------------------------------------------------
+
+test_that("fake parameters - missing dependency error from topological_sort", {
   add.interval.col(
     name="fake_parameter",
     FUN="mean",
@@ -171,10 +176,322 @@ test_that("fake parameters", {
   )
   expect_error(
     sort.interval.cols(),
-    regexp="Invalid dependencies for interval column (please report this as a bug): fake_parameter The following dependencies are missing: does_not_exist",
-    fixed=TRUE
+    regexp="Missing interval column definitions for:.*does_not_exist",
+    class="pknca_error_missing_dependency"
   )
 })
 
 # Reset the original state
 assign("interval.cols", original_state, envir=PKNCA:::.PKNCAEnv)
+assign("interval.cols_sorted", NULL, envir=PKNCA:::.PKNCAEnv)
+
+# ---------------------------------------------------------------------------
+# sort.interval.cols — circular dependency (topological_sort integration)
+# ---------------------------------------------------------------------------
+
+test_that("circular dependency detected via sort.interval.cols", {
+  add.interval.col(name="loop1", FUN="mean", unit_type="conc", pretty_name="loop1", desc="loop1")
+  add.interval.col(name="loop2", FUN="mean", unit_type="conc", pretty_name="loop2", desc="loop2", depends="loop1")
+  # Manually inject circular dependency
+  current <- get("interval.cols", envir=PKNCA:::.PKNCAEnv)
+  current[["loop1"]]$depends <- "loop2"
+  assign("interval.cols", current, envir=PKNCA:::.PKNCAEnv)
+  assign("interval.cols_sorted", NULL, envir=PKNCA:::.PKNCAEnv)
+  
+  expect_error(
+    sort.interval.cols(),
+    class="pknca_error_circular_dependency"
+  )
+})
+
+# Reset the original state
+assign("interval.cols", original_state, envir=PKNCA:::.PKNCAEnv)
+assign("interval.cols_sorted", NULL, envir=PKNCA:::.PKNCAEnv)
+
+# ---------------------------------------------------------------------------
+# topological_sort — unit tests
+# ---------------------------------------------------------------------------
+
+make_spec <- function(...) {
+  args <- list(...)
+  lapply(args, function(dep) list(depends = dep))
+}
+
+# ---------------------------------------------------------------------------
+# 1. Happy-path tests
+# ---------------------------------------------------------------------------
+
+test_that("single node with no dependencies returns that node", {
+  specs <- make_spec(a = NULL)
+  expect_equal(topological_sort(specs), "a")
+})
+
+test_that("two independent nodes are both returned", {
+  specs <- make_spec(b = NULL, a = NULL)
+  expect_setequal(topological_sort(specs), c("a", "b"))
+})
+
+test_that("simple linear chain: a -> b -> c", {
+  specs <- list(
+    a = list(depends = NULL),
+    b = list(depends = "a"),
+    c = list(depends = "b")
+  )
+  result <- topological_sort(specs)
+  expect_equal(result, c("a", "b", "c"))
+  expect_lt(which(result == "a"), which(result == "b"))
+  expect_lt(which(result == "b"), which(result == "c"))
+})
+
+test_that("diamond dependency: a -> b, a -> c, b -> d, c -> d", {
+  specs <- list(
+    a = list(depends = NULL),
+    b = list(depends = "a"),
+    c = list(depends = "a"),
+    d = list(depends = c("b", "c"))
+  )
+  result <- topological_sort(specs)
+  expect_length(result, 4)
+  expect_lt(which(result == "a"), which(result == "b"))
+  expect_lt(which(result == "a"), which(result == "c"))
+  expect_lt(which(result == "b"), which(result == "d"))
+  expect_lt(which(result == "c"), which(result == "d"))
+})
+
+test_that("node with multiple dependencies lists all deps before it", {
+  specs <- list(
+    x = list(depends = NULL),
+    y = list(depends = NULL),
+    z = list(depends = c("x", "y"))
+  )
+  result <- topological_sort(specs)
+  expect_length(result, 3)
+  expect_lt(which(result == "x"), which(result == "z"))
+  expect_lt(which(result == "y"), which(result == "z"))
+})
+
+test_that("all nodes independent - all returned", {
+  specs <- make_spec(delta = NULL, alpha = NULL, gamma = NULL, beta = NULL)
+  expect_setequal(topological_sort(specs), names(specs))
+})
+
+test_that("empty depends vector treated same as NULL", {
+  specs <- list(
+    a = list(depends = character(0)),
+    b = list(depends = "a")
+  )
+  result <- topological_sort(specs)
+  expect_lt(which(result == "a"), which(result == "b"))
+})
+
+test_that("result contains every parameter exactly once", {
+  specs <- list(
+    a = list(depends = NULL),
+    b = list(depends = "a"),
+    c = list(depends = "a"),
+    d = list(depends = c("b", "c")),
+    e = list(depends = NULL)
+  )
+  result <- topological_sort(specs)
+  expect_setequal(result, names(specs))
+  expect_length(result, length(specs))
+})
+
+test_that("deterministic: same result on repeated calls", {
+  specs <- list(
+    e = list(depends = NULL),
+    d = list(depends = NULL),
+    c = list(depends = c("d", "e")),
+    b = list(depends = "c"),
+    a = list(depends = NULL)
+  )
+  expect_equal(topological_sort(specs), topological_sort(specs))
+})
+
+# ---------------------------------------------------------------------------
+# 2. Structural validation errors
+# ---------------------------------------------------------------------------
+
+test_that("error when specs is not a list", {
+  expect_error(topological_sort(c(a = 1, b = 2)))
+})
+
+test_that("error when specs is an unnamed list", {
+  expect_error(topological_sort(list(list(depends = NULL))))
+})
+
+test_that("error when specs is empty", {
+  expect_error(topological_sort(list()))
+})
+
+test_that("error when specs has duplicate names", {
+  specs <- list(a = list(depends = NULL), a = list(depends = NULL))
+  expect_error(topological_sort(specs))
+})
+
+test_that("error when a spec element is missing 'depends' field", {
+  specs <- list(
+    a = list(foo = NULL),
+    b = list(depends = "a")
+  )
+  expect_error(
+    topological_sort(specs),
+    class = "pknca_error_invalid_spec_structure"
+  )
+})
+
+test_that("error message for missing 'depends' field mentions the column name", {
+  specs <- list(broken = list(value = 42))
+  expect_error(
+    topological_sort(specs),
+    regexp = "broken",
+    class = "pknca_error_invalid_spec_structure"
+  )
+})
+
+test_that("error when depends is not a character vector", {
+  specs <- list(
+    a = list(depends = NULL),
+    b = list(depends = 1L)
+  )
+  expect_error(topological_sort(specs))
+})
+
+test_that("error when depends contains NA", {
+  specs <- list(
+    a = list(depends = NULL),
+    b = list(depends = NA_character_)
+  )
+  expect_error(topological_sort(specs))
+})
+
+# ---------------------------------------------------------------------------
+# 3. Missing dependency errors
+# ---------------------------------------------------------------------------
+
+test_that("error when dependency references non-existent parameter", {
+  specs <- list(
+    a = list(depends = NULL),
+    b = list(depends = c("a", "ghost"))
+  )
+  expect_error(
+    topological_sort(specs),
+    class = "pknca_error_missing_dependency"
+  )
+})
+
+test_that("error message for missing dependency names the missing param", {
+  specs <- list(b = list(depends = "missing_param"))
+  err <- tryCatch(topological_sort(specs), error = function(e) e)
+  expect_true(inherits(err, "pknca_error_missing_dependency"))
+  expect_match(conditionMessage(err), "missing_param")
+})
+
+test_that("all missing dependencies are listed in the error", {
+  specs <- list(a = list(depends = c("x", "y", "z")))
+  err <- tryCatch(topological_sort(specs), error = function(e) e)
+  expect_true(inherits(err, "pknca_error_missing_dependency"))
+  expect_match(conditionMessage(err), "x")
+  expect_match(conditionMessage(err), "y")
+  expect_match(conditionMessage(err), "z")
+})
+
+# ---------------------------------------------------------------------------
+# 4. Circular dependency errors
+# ---------------------------------------------------------------------------
+
+test_that("direct self-loop triggers circular dependency error", {
+  specs <- list(a = list(depends = "a"))
+  expect_error(
+    topological_sort(specs),
+    class = "pknca_error_circular_dependency"
+  )
+})
+
+test_that("two-node cycle triggers circular dependency error", {
+  specs <- list(
+    a = list(depends = "b"),
+    b = list(depends = "a")
+  )
+  expect_error(
+    topological_sort(specs),
+    class = "pknca_error_circular_dependency"
+  )
+})
+
+test_that("three-node cycle triggers circular dependency error", {
+  specs <- list(
+    a = list(depends = "c"),
+    b = list(depends = "a"),
+    c = list(depends = "b")
+  )
+  expect_error(
+    topological_sort(specs),
+    class = "pknca_error_circular_dependency"
+  )
+})
+
+test_that("cycle embedded in larger graph still triggers error", {
+  specs <- list(
+    root  = list(depends = NULL),
+    good  = list(depends = "root"),
+    loop1 = list(depends = "loop2"),
+    loop2 = list(depends = "loop1")
+  )
+  expect_error(
+    topological_sort(specs),
+    class = "pknca_error_circular_dependency"
+  )
+})
+
+test_that("circular dependency error message is informative", {
+  specs <- list(a = list(depends = "b"), b = list(depends = "a"))
+  err <- tryCatch(topological_sort(specs), error = function(e) e)
+  expect_true(inherits(err, "pknca_error_circular_dependency"))
+  expect_match(conditionMessage(err), "(?i)circular")
+})
+
+# ---------------------------------------------------------------------------
+# 5. Edge cases
+# ---------------------------------------------------------------------------
+
+test_that("single node that depends on itself = circular error", {
+  specs <- list(only = list(depends = "only"))
+  expect_error(
+    topological_sort(specs),
+    class = "pknca_error_circular_dependency"
+  )
+})
+
+test_that("large linear chain is handled correctly", {
+  n <- 50
+  nms <- paste0("p", seq_len(n))
+  specs <- setNames(
+    lapply(seq_len(n), function(i) {
+      list(depends = if (i == 1) NULL else nms[i - 1])
+    }),
+    nms
+  )
+  result <- topological_sort(specs)
+  expect_setequal(result, nms)
+  for (i in seq_len(n - 1)) {
+    expect_lt(which(result == nms[i]), which(result == nms[i + 1]))
+  }
+})
+
+test_that("wide graph (many independent nodes) all returned", {
+  nms <- paste0("node", 1:20)
+  specs <- setNames(lapply(nms, function(nm) list(depends = NULL)), nms)
+  result <- topological_sort(specs)
+  expect_setequal(result, nms)
+  expect_length(result, length(nms))
+})
+
+test_that("extra fields in spec are allowed and ignored", {
+  specs <- list(
+    a = list(depends = NULL, extra = "ignored", value = 42),
+    b = list(depends = "a", meta = list(1, 2, 3))
+  )
+  result <- topological_sort(specs)
+  expect_lt(which(result == "a"), which(result == "b"))
+})

--- a/tests/testthat/test-pk.calc.simple.R
+++ b/tests/testthat/test-pk.calc.simple.R
@@ -446,12 +446,12 @@ test_that("pk.calc.aucabove", {
     as.data.frame(o_nca),
     tibble::tibble(
       start = 0, end = 6,
-      PPTESTCD = c("ctrough", "cstart", "aucabove.predose.all", "aucabove.trough.all"),
+      PPTESTCD = c("ctrough", "cstart", "aucabove.trough.all", "aucabove.predose.all"),
       PPORRES =
         c(
           3, 2,
-          pk.calc.aucabove(conc = d_conc$conc, time = d_conc$time, conc_above = 2),
-          pk.calc.aucabove(conc = d_conc$conc, time = d_conc$time, conc_above = 3)
+          pk.calc.aucabove(conc = d_conc$conc, time = d_conc$time, conc_above = 3),
+          pk.calc.aucabove(conc = d_conc$conc, time = d_conc$time, conc_above = 2)
         ),
       exclude = NA_character_
     )


### PR DESCRIPTION

Replaces the existing while-loop based dependency resolution in sort.interval.cols() with a proper topological sort implementation using Kahn's algorithm.

• Implements Kahn's algorithm with insertion-order tie-breaking to preserve original parameter registration order • Validates structure of specs before sorting
• Detects and reports missing dependencies with clear error class pknca_error_missing_dependency • Detects and reports circular dependencies with clear error class pknca_error_circular_dependency