### PR TITLE
docs: fix typos, grammar, and copy-paste errors across documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,8 +35,7 @@ Description: Compute standard Non-Compartmental Analysis (NCA) parameters for
     typical pharmacokinetic analyses and summarize them.
 License: AGPL-3
 URL: https://humanpred.github.io/pknca/,
-    https://github.com/humanpred/pknca,
-    http://humanpred.github.io/pknca/
+    https://github.com/humanpred/pknca
 BugReports: https://github.com/humanpred/pknca/issues
 NeedsCompilation: no
 VignetteBuilder: knitr

--- a/R/PKNCA.options.R
+++ b/R/PKNCA.options.R
@@ -426,7 +426,7 @@
 #'   of the values when used in another function)
 #' @param name An option name to use with the `value`.
 #' @param value An option value (paired with the `name`) to set or check (if
-#'   `NULL`, ).
+#'   `NULL`, the current value of the option is returned).
 #' @returns If...
 #' \describe{
 #'   \item{no arguments are given}{returns the current options.}

--- a/R/PKNCA.options.R
+++ b/R/PKNCA.options.R
@@ -204,7 +204,7 @@
       if (is.na(x)) {
         stop("Could not convert allow.tmax.in.half.life to a logical value")
       } else {
-        warning("Converting allow.tmax.in.half.life to a logical value: ", ret)
+        warning("Converting allow.tmax.in.half.life to a logical value: ", x)
       }
     }
     x

--- a/R/auc.R
+++ b/R/auc.R
@@ -1,4 +1,4 @@
-#' A compute the Area Under the (Moment) Curve
+#' Compute the Area Under the (Moment) Curve
 #'
 #' Compute the area under the curve (AUC) and the area under the moment curve
 #' (AUMC) for pharmacokinetic (PK) data.  AUC and AUMC are used for many
@@ -32,7 +32,7 @@
 #'   the curve (if log integration is used; not required for AUC or AUMC
 #'   functions)
 #' @param fun_inf The function to use for extrapolation from the final
-#'   measurement to infinite time (not required for AUC or AUMC functions.
+#'   measurement to infinite time (not required for AUC or AUMC functions).
 #' @param ... For functions other than `pk.calc.auxc`, these values are passed
 #'   to `pk.calc.auxc`
 #' @returns A numeric value for the AU(M)C.

--- a/R/auciv.R
+++ b/R/auciv.R
@@ -105,7 +105,7 @@ add.interval.col(
   unit_type = "auc",
   pretty_name = "AUCinf,pred (IV dosing)",
   depends = c("aucinf.pred", "c0"),
-  desc = "The  calculated with back-extrapolation for intravenous dosing using extrapolated C0",
+  desc = "The AUCinf,pred calculated with back-extrapolation for intravenous dosing using extrapolated C0",
   sparse = FALSE,
   formalsmap = list(auc="aucinf.pred")
 )

--- a/R/check.intervals.R
+++ b/R/check.intervals.R
@@ -34,7 +34,7 @@ check.interval.specification <- function(x) {
                         collapse=", ")))
   }
   interval_cols <- get.interval.cols()
-  # Check the value of each column
+  # Check the edit of each column
   for (n in names(interval_cols)) {
     if (!(n %in% names(x))) {
       if (is.vector(interval_cols[[n]]$values)) {

--- a/R/check.intervals.R
+++ b/R/check.intervals.R
@@ -34,7 +34,7 @@ check.interval.specification <- function(x) {
                         collapse=", ")))
   }
   interval_cols <- get.interval.cols()
-  # Check the edit of each column
+  # Check the value of each column
   for (n in names(interval_cols)) {
     if (!(n %in% names(x))) {
       if (is.vector(interval_cols[[n]]$values)) {

--- a/R/class-PKNCAdose.R
+++ b/R/class-PKNCAdose.R
@@ -18,12 +18,12 @@
 #' @param time.nominal (optional) The name of the nominal time column (if the
 #'   main time variable is actual time.  The `time.nominal` is not used during
 #'   calculations; it is available to assist with data summary and checking.
-#' @param exclude (optional) The name of a column with concentrations to exclude
+#' @param exclude (optional) The name of a column with doses to exclude
 #'   from calculations and summarization.  If given, the column should have
-#'   values of `NA` or `""` for concentrations to include and non-empty text for
-#'   concentrations to exclude.
+#'   values of `NA` or `""` for doses to include and non-empty text for
+#'   doses to exclude.
 #' @param ... Ignored.
-#' @returns A PKNCAconc object that can be used for automated NCA.
+#' @returns A PKNCAdose object that can be used for automated NCA.
 #' @details The `formula` for a `PKNCAdose` object can be
 #'   given three ways: one-sided (missing left side), one-sided (missing
 #'   right side), or two-sided.  Each of the three ways can be given
@@ -37,7 +37,8 @@
 #'   `dose~.|treatment+subject`, and only a single row may be given
 #'   per group.  When the right side is missing, PKNCA assumes that the
 #'   same dose is given in every interval.  When given as a two-sided
-#'   formula
+#'   formula, both the dose amount and time are used directly from the
+#'   data.
 #' @family PKNCA objects
 #' @export
 PKNCAdose <- function(data, ...)

--- a/R/class-summary_PKNCAresults.R
+++ b/R/class-summary_PKNCAresults.R
@@ -136,7 +136,7 @@ summary.PKNCAresults <- function(object, ...,
       X = object$data$intervals[, parameter_cols, drop = FALSE],
       FUN = any
     )
-  # Then, filter them the the ones that have any "TRUE" values
+  # Then, filter them to the ones that have any "TRUE" values
   result_data_cols_list <- result_data_cols_list[unlist(result_data_cols_list)]
 
   # Prepare for unit management
@@ -219,7 +219,7 @@ get_summary_PKNCAresults_result_number_col <- function(object) {
   intersect(c("PPSTRES", "PPORRES"), names(data))[1]
 }
 
-# Get the column name with the result unitss to use for summarization
+# Get the column name with the result units to use for summarization
 get_summary_PKNCAresults_result_unit_col <- function(object) {
   if (is.data.frame(object)) {
     data <- object

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -73,7 +73,7 @@ exclude.default <- function(object, reason, mask, FUN) {
       mask <- !is.na(reason)
     }
   } else if (!xor(missing(mask), missing(FUN))) {
-    stop("Either mask for FUN must be given (but not both).")
+    stop("Either mask or FUN must be given (but not both).")
   }
   if (!(length(reason) %in% c(1, nrow(object[[dataname]])))) {
     stop("reason must be a scalar or have the same length as the data.")

--- a/R/general.functions.R
+++ b/R/general.functions.R
@@ -154,7 +154,7 @@ signifString.default <- function(x, digits=6, sci_range=6, sci_sep="e", si_range
     # current value
     toplog <- log10(abs(xtmp))
     # When the order of magnitude is an exact log 10, move up one so
-    # that the math works for determing the lower log.
+    # that the math works for determining the lower log.
     mask.exact.log <- (toplog %% 1) %in% 0
     toplog[mask.exact.log] <- toplog[mask.exact.log] + 1
     toplog <- ceiling(toplog)

--- a/R/half.life.R
+++ b/R/half.life.R
@@ -886,7 +886,7 @@ get_halflife_points_single <- function(conc, results, time_start, time_end, rowi
       ret$hl_used <- conc_included$include_half.life %in% TRUE
     } else {
       # Shift the time by time_start to account for the fact that
-      # lambda.z.time.first and are relative to the start of the interval
+      # lambda.z.time.first and lambda.z.time.last are relative to the start of the interval
       time_first <- time_start + results$PPORRES[results$PPTESTCD %in% "lambda.z.time.first"]
       time_last <- time_start + results$PPORRES[results$PPTESTCD %in% "lambda.z.time.last"]
       excluded <-

--- a/R/interpolate.conc.R
+++ b/R/interpolate.conc.R
@@ -188,7 +188,7 @@ interpolate.conc <- function(conc, time, time.out,
   } else if (all(data$conc == 0)) {
     ret <- 0
   } else if (time.out > tlast) {
-    stop("`interpolate.conc()` can only works through Tlast, please use `interp.extrap.conc()` to combine both interpolation and extrapolation.")
+    stop("`interpolate.conc()` can only work through Tlast, please use `interp.extrap.conc()` to combine both interpolation and extrapolation.")
   } else if (time.out %in% data$time) {
     # See if there is an exact time match and return that if it
     # exists.

--- a/R/interpolate.conc.R
+++ b/R/interpolate.conc.R
@@ -188,7 +188,7 @@ interpolate.conc <- function(conc, time, time.out,
   } else if (all(data$conc == 0)) {
     ret <- 0
   } else if (time.out > tlast) {
-    stop("`interpolate.conc()` can only work through Tlast, please use `interp.extrap.conc()` to combine both interpolation and extrapolation.")
+    stop("`interpolate.conc()` only works through Tlast, please use `interp.extrap.conc()` to combine both interpolation and extrapolation.")
   } else if (time.out %in% data$time) {
     # See if there is an exact time match and return that if it
     # exists.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To install the development version from GitHub, type the following commands:
     # Summarize the results
     summary(o_results)
 
-More help is available in the function help files. Be sure to look at the PKNCA.options function for choices on making PKNCA conform to your company’s business rules on calculation and summarization.
+More help is available in the function help files. Be sure to look at the PKNCA.options function for options to make PKNCA conform to your company’s business rules on calculation and summarization.
 
 # Feature requests
 

--- a/man/PKNCA.Rd
+++ b/man/PKNCA.Rd
@@ -41,7 +41,6 @@ Useful links:
 \itemize{
   \item \url{https://humanpred.github.io/pknca/}
   \item \url{https://github.com/humanpred/pknca}
-  \item \url{http://humanpred.github.io/pknca/}
   \item Report bugs at \url{https://github.com/humanpred/pknca/issues}
 }
 

--- a/man/PKNCA.options.Rd
+++ b/man/PKNCA.options.Rd
@@ -17,7 +17,7 @@ of the values when used in another function)}
 \item{name}{An option name to use with the \code{value}.}
 
 \item{value}{An option value (paired with the \code{name}) to set or check (if
-\code{NULL}, ).}
+\code{NULL}, the current value of the option is returned).}
 }
 \value{
 If...

--- a/man/PKNCAdose.Rd
+++ b/man/PKNCAdose.Rd
@@ -52,10 +52,10 @@ amount must be given (the left hand side of the \code{formula}).}
 main time variable is actual time.  The \code{time.nominal} is not used during
 calculations; it is available to assist with data summary and checking.}
 
-\item{exclude}{(optional) The name of a column with concentrations to exclude
+\item{exclude}{(optional) The name of a column with doses to exclude
 from calculations and summarization.  If given, the column should have
-values of \code{NA} or \code{""} for concentrations to include and non-empty text for
-concentrations to exclude.}
+values of \code{NA} or \code{""} for doses to include and non-empty text for
+doses to exclude.}
 
 \item{doseu}{Either unit values (e.g. "mg") or column names within the data
 where units are provided.}
@@ -63,7 +63,7 @@ where units are provided.}
 \item{doseu_pref}{Preferred units for reporting (not column names)}
 }
 \value{
-A PKNCAconc object that can be used for automated NCA.
+A PKNCAdose object that can be used for automated NCA.
 }
 \description{
 Create a PKNCAdose object
@@ -82,7 +82,8 @@ side must be specified as a period (\code{.}):
 \code{dose~.|treatment+subject}, and only a single row may be given
 per group.  When the right side is missing, PKNCA assumes that the
 same dose is given in every interval.  When given as a two-sided
-formula
+formula, both the dose amount and time are used directly from the
+data.
 }
 \seealso{
 Other PKNCA objects: 

--- a/man/auc_integrate.Rd
+++ b/man/auc_integrate.Rd
@@ -39,7 +39,7 @@ the curve (if log integration is used; not required for AUC or AUMC
 functions)}
 
 \item{fun_inf}{The function to use for extrapolation from the final
-measurement to infinite time (not required for AUC or AUMC functions.}
+measurement to infinite time (not required for AUC or AUMC functions).}
 }
 \description{
 Support function for AUC integration

--- a/man/pk.calc.auxc.Rd
+++ b/man/pk.calc.auxc.Rd
@@ -14,7 +14,7 @@
 \alias{pk.calc.aumc.inf.obs}
 \alias{pk.calc.aumc.inf.pred}
 \alias{pk.calc.aumc.all}
-\title{A compute the Area Under the (Moment) Curve}
+\title{Compute the Area Under the (Moment) Curve}
 \usage{
 pk.calc.auxc(
   conc,
@@ -97,7 +97,7 @@ the curve (if log integration is used; not required for AUC or AUMC
 functions)}
 
 \item{fun_inf}{The function to use for extrapolation from the final
-measurement to infinite time (not required for AUC or AUMC functions.}
+measurement to infinite time (not required for AUC or AUMC functions).}
 
 \item{...}{For functions other than \code{pk.calc.auxc}, these values are passed
 to \code{pk.calc.auxc}}

--- a/tests/testthat/test-exclude.R
+++ b/tests/testthat/test-exclude.R
@@ -97,13 +97,13 @@ test_that("exclude.default", {
 
   expect_error(exclude.default(obj1,
                               reason="Just because"),
-               regexp="Either mask for FUN must be given \\(but not both\\).",
+               regexp="Either mask or FUN must be given \\(but not both\\).",
                info="One of mask and FUN must be given")
   expect_error(exclude.default(obj1,
                               reason="Just because",
                               mask=rep(TRUE, 5),
                               FUN=function(x) rep(TRUE, nrow(x$data))),
-               regexp="Either mask for FUN must be given \\(but not both\\).",
+               regexp="Either mask or FUN must be given \\(but not both\\).",
                info="Both mask and FUN may not be given")
   obj2 <- obj1
   obj2$columns$exclude <- NULL

--- a/tests/testthat/test-interpolate.conc.R
+++ b/tests/testthat/test-interpolate.conc.R
@@ -83,7 +83,7 @@ test_that("interpolate.conc expected errors", {
       time=0:2,
       time.out=1.5
     ),
-    regexp="`interpolate.conc()` can only work through Tlast, please use `interp.extrap.conc()` to combine both interpolation and extrapolation.",
+    regexp="`interpolate.conc()` only works through Tlast, please use `interp.extrap.conc()` to combine both interpolation and extrapolation.",
     fixed=TRUE
   )
 })

--- a/tests/testthat/test-interpolate.conc.R
+++ b/tests/testthat/test-interpolate.conc.R
@@ -83,7 +83,7 @@ test_that("interpolate.conc expected errors", {
       time=0:2,
       time.out=1.5
     ),
-    regexp="`interpolate.conc()` can only works through Tlast, please use `interp.extrap.conc()` to combine both interpolation and extrapolation.",
+    regexp="`interpolate.conc()` can only work through Tlast, please use `interp.extrap.conc()` to combine both interpolation and extrapolation.",
     fixed=TRUE
   )
 })

--- a/vignettes/v01-introduction-and-usage.Rmd
+++ b/vignettes/v01-introduction-and-usage.Rmd
@@ -24,7 +24,7 @@ a reasonable answer without user intervention (load, calculate, and summarize),
 but it allows the user to override the automatic selections at any point.
 
 The library design is modular to allow expansion based on needs
-unforseen by the authors including new NCA parameters, novel data
+unforeseen by the authors including new NCA parameters, novel data
 cleaning methods, and modular summarization decisions.  Expanding the
 library will be discussed in a separate vignette.
 

--- a/vignettes/v07-post-processing.Rmd
+++ b/vignettes/v07-post-processing.Rmd
@@ -171,7 +171,7 @@ results_obj2 <- pk.nca(data_obj2)
 results_norm_by_col <- normalize_by_col(
   results_obj2,
   col = "weight",
-  unit = "weigth_unit",
+  unit = "weight_unit",
   parameters = "cmax",
   suffix = ".wn"
 )

--- a/vignettes/v80-writing-parameter-functions.Rmd
+++ b/vignettes/v80-writing-parameter-functions.Rmd
@@ -33,7 +33,7 @@ The starting point to writing a new NCA parameter is writing the function that c
 * `time.dose` is the numeric vector of time for the doses.
 * `duration.dose` is the duration of a dose (usually for intravenous infusions)
 * `start` and `end` are the scalar numbers for the start and end time of the current interval.  NOTE: `end` may be `Inf` (infinity).
-* `options` are the PKNCA options used for the current calculation usually as defined by the `PKNCA.option` function (though these options may be over-ridden by the `options` argument to the `PKNCAdata` function.
+* `options` are the PKNCA options used for the current calculation usually as defined by the `PKNCA.options` function (though these options may be over-ridden by the `options` argument to the `PKNCAdata` function.
 * Or, any NCA parameters by name (as given by `names(get.interval.cols())`).
 
 The function should return either a scalar which is the value for the parameter (usually the case) or a data.frame with parameters named for each parameter calculated.  For an example of returning a data.frame, see the `half.life` function.


### PR DESCRIPTION
- Fix "unforseen" typo in v01 vignette
- Fix "weigth_unit" typo in v07 vignette (wrong column name reference)
- Fix "PKNCA.option" -> "PKNCA.options" in v80 vignette
- Fix "A compute" -> "Compute" stray word in auc.R title
- Fix missing closing parenthesis in auc.R fun_inf param docs
- Fix PKNCAdose roxygen: wrong class name (PKNCAconc -> PKNCAdose),
  wrong entity (concentrations -> doses), and truncated Details section
- Fix incomplete PKNCA.options param description for NULL value
- Fix "mask for FUN" -> "mask or FUN" in exclude.R error message and tests
- Improve awkward phrasing in README.md
- Remove duplicate HTTP URL from DESCRIPTION
- Update corresponding man pages to match roxygen changes

https://claude.ai/code/session_01KYp8qRpEi6L8rN9yaszJKm